### PR TITLE
Remove IE11 code at compile-time

### DIFF
--- a/examples/index_ie11.html
+++ b/examples/index_ie11.html
@@ -18,7 +18,7 @@
             .ease-out { transition-timing-function: cubic-bezier(0, 0, 0.2, 1); }
     </style>
 
-    <script src="https://polyfill.io/v3/polyfill.js?features=MutationObserver%2CArray.from%2CArray.prototype.forEach%2CMap%2CSet%2CArray.prototype.includes%2CString.prototype.includes%2CPromise%2CNodeList.prototype.forEach%2CObject.values%2CReflect%2CReflect.set%2CString.prototype.startsWith%2CArray.prototype.find%2CArray.prototype.findIndex%2CElement.prototype.closest%2CElement.prototype.remove%2CCustomEvent%2CElement.prototype.classList"></script>
+    <script src="https://polyfill.io/v3/polyfill.js?features=MutationObserver%2CArray.from%2CArray.prototype.forEach%2CMap%2CSet%2CArray.prototype.includes%2CString.prototype.includes%2CPromise%2CNodeList.prototype.forEach%2CObject.values%2CReflect%2CReflect.set%2CString.prototype.startsWith%2CArray.prototype.find%2CArray.prototype.findIndex%2CElement.prototype.closest%2CElement.prototype.remove%2CCustomEvent%2CElement.prototype.classList%2CHTMLTemplateElement"></script>
     <script src="https://unpkg.com/shim-selected-options" async></script>
     <script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.3.0/proxy.min.js"></script>
 
@@ -210,6 +210,30 @@
                     </script>
                 </td>
             </tr>
+
+            <tr>
+                <td>x-for</td>
+                <td>
+                    <div x-data="{ items: ['foo', 'bar'], foo: 'bar' }">
+                        <input type="checkbox" x-model="items" value="foo">
+                        <input type="checkbox" x-model="items" value="bar">
+                        <input type="checkbox" x-model="items" value="baz">
+
+                        <button @click="items = ['bar', 'bob']">hey</button>
+
+                        <template x-for="item in items" :key="item">
+                            <div x-text="item" x-transition:enter-start="opacity-0 scale-90"
+                                x-transition:enter="ease-out transition-medium"
+                                x-transition:enter-end="opacity-100 scale-100"
+                                x-transition:leave-start="opacity-100 scale-100"
+                                x-transition:leave="ease-in transition-faster"
+                                x-transition:leave-end="opacity-0 scale-90"
+                            ></div>
+                        </template>
+                    </div>
+                </td>
+            </tr>
+
             <tr>
                 <td>Transitions</td>
                 <td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alpinejs",
-  "version": "1.2.0",
+  "version": "1.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4316,6 +4316,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+      "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -5233,6 +5242,27 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-strip-code": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-strip-code/-/rollup-plugin-strip-code-0.2.7.tgz",
+      "integrity": "sha512-+5t9u/VrHPSfiRWWKMVin+KOtFwFak337FAZxeTjxYDjB3DDoHBQRkXHQvBn713eAfW81t41mGuysqsMXiuTjw==",
+      "dev": true,
+      "requires": {
+        "magic-string": "0.25.3",
+        "rollup-pluginutils": "2.8.1"
+      },
+      "dependencies": {
+        "rollup-pluginutils": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
+          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^0.6.1"
+          }
+        }
+      }
+    },
     "rollup-plugin-terser": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz",
@@ -5533,6 +5563,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-filesize": "^6.2.1",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-strip-code": "^0.2.7",
     "rollup-plugin-terser": "^5.1.3"
   },
   "dependencies": {}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default [{
                 exclude: 'node_modules/**'
             }),
             stripCode({
-                start_comment: 'IE11-ONLY:END',
+                start_comment: 'IE11-ONLY:START',
                 end_comment: 'IE11-ONLY:END'
             })
         ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,8 @@
 import babel from 'rollup-plugin-babel';
 import filesize from 'rollup-plugin-filesize';
-import {
-    terser
-} from "rollup-plugin-terser";
+import { terser } from "rollup-plugin-terser";
 import resolve from "rollup-plugin-node-resolve"
+import stripCode from 'rollup-plugin-strip-code';
 
 
 export default [{
@@ -14,19 +13,23 @@ export default [{
             format: 'umd',
             sourcemap: true,
         },
-            plugins: [
-                resolve(),
-                filesize(),
-                terser({
-                    mangle: false,
-                    compress: {
-                        drop_debugger: false,
-                    },
-                }),
-                babel({
-                    exclude: 'node_modules/**'
-                })
-            ]
+        plugins: [
+            resolve(),
+            filesize(),
+            terser({
+                mangle: false,
+                compress: {
+                    drop_debugger: false,
+                },
+            }),
+            babel({
+                exclude: 'node_modules/**'
+            }),
+            stripCode({
+                start_comment: 'IE11-ONLY:END',
+                end_comment: 'IE11-ONLY:END'
+            })
+        ]
     },
     {
         input: 'src/index.js',

--- a/src/component.js
+++ b/src/component.js
@@ -19,14 +19,12 @@ export default class Component {
         const unobservedData = saferEval(dataExpression, {})
 
         /* IE11-ONLY:START */
-        if (window.document.documentMode) {
             // For IE11, add our magic properties to the original data for access.
             // Since the polyfill proxy does not allow properties to be added after creation
-                unobservedData.$el = null
-                unobservedData.$refs = null
-                unobservedData.$nextTick = null
-            /* IE11-ONLY:END */
-        }
+            unobservedData.$el = null
+            unobservedData.$refs = null
+            unobservedData.$nextTick = null
+        /* IE11-ONLY:END */
 
         // Construct a Proxy-based observable. This will be used to handle reactivity.
         this.$data = this.wrapDataInObservable(unobservedData)
@@ -334,7 +332,6 @@ export default class Component {
         var refObj = {}
 
         /* IE11-ONLY:START */
-        if (window.document.documentMode) {
             //add any properties that might be necessary for ie11 proxy
             refObj.$isRefsProxy = false;
             refObj.$isAlpineProxy = false;
@@ -347,7 +344,6 @@ export default class Component {
                     refObj[el.getAttribute('x-ref')] = true
                 }
             })
-        }
         /* IE11-ONLY:END */
 
 

--- a/src/component.js
+++ b/src/component.js
@@ -19,12 +19,14 @@ export default class Component {
         const unobservedData = saferEval(dataExpression, {})
 
         /* IE11-ONLY:START */
-        // For IE11, add our magic properties to the original data for access.
-        // Since the polyfill proxy does not allow properties to be added after creation
-            unobservedData.$el = null
-            unobservedData.$refs = null
-            unobservedData.$nextTick = null
-        /* IE11-ONLY:END */
+        if (window.document.documentMode) {
+            // For IE11, add our magic properties to the original data for access.
+            // Since the polyfill proxy does not allow properties to be added after creation
+                unobservedData.$el = null
+                unobservedData.$refs = null
+                unobservedData.$nextTick = null
+            /* IE11-ONLY:END */
+        }
 
         // Construct a Proxy-based observable. This will be used to handle reactivity.
         this.$data = this.wrapDataInObservable(unobservedData)
@@ -332,18 +334,20 @@ export default class Component {
         var refObj = {}
 
         /* IE11-ONLY:START */
-        //add any properties that might be necessary for ie11 proxy
-        refObj.$isRefsProxy = false;
-        refObj.$isAlpineProxy = false;
+        if (window.document.documentMode) {
+            //add any properties that might be necessary for ie11 proxy
+            refObj.$isRefsProxy = false;
+            refObj.$isAlpineProxy = false;
 
-        // If we are in IE, since the polyfill needs all properties to be defined before building the proxy,
-        // we just loop on the element, look for any x-ref and create a the property on a fake object.
-        // We don't need to put a real value since it will be resolved by the proxy class
-        this.walkAndSkipNestedComponents(self.$el, el => {
-            if (el.hasAttribute('x-ref')) {
-                refObj[el.getAttribute('x-ref')] = true
-            }
-        })
+            // If we are in IE, since the polyfill needs all properties to be defined before building the proxy,
+            // we just loop on the element, look for any x-ref and create a the property on a fake object.
+            // We don't need to put a real value since it will be resolved by the proxy class
+            this.walkAndSkipNestedComponents(self.$el, el => {
+                if (el.hasAttribute('x-ref')) {
+                    refObj[el.getAttribute('x-ref')] = true
+                }
+            })
+        }
         /* IE11-ONLY:END */
 
 

--- a/src/component.js
+++ b/src/component.js
@@ -18,13 +18,13 @@ export default class Component {
 
         const unobservedData = saferEval(dataExpression, {})
 
+        /* IE11-ONLY:START */
         // For IE11, add our magic properties to the original data for access.
-        // Since the polyfill proxy does not allow properties to be added after creation 
-        if (window.document.documentMode) {
-            unobservedData.$el = null 
-            unobservedData.$refs = null 
-            unobservedData.$nextTick = null 
-        }
+        // Since the polyfill proxy does not allow properties to be added after creation
+            unobservedData.$el = null
+            unobservedData.$refs = null
+            unobservedData.$nextTick = null
+        /* IE11-ONLY:END */
 
         // Construct a Proxy-based observable. This will be used to handle reactivity.
         this.$data = this.wrapDataInObservable(unobservedData)
@@ -330,7 +330,8 @@ export default class Component {
         var self = this
 
         var refObj = {}
-        
+
+        /* IE11-ONLY:START */
         //add any properties that might be necessary for ie11 proxy
         refObj.$isRefsProxy = false;
         refObj.$isAlpineProxy = false;
@@ -338,13 +339,13 @@ export default class Component {
         // If we are in IE, since the polyfill needs all properties to be defined before building the proxy,
         // we just loop on the element, look for any x-ref and create a the property on a fake object.
         // We don't need to put a real value since it will be resolved by the proxy class
-        if (window.document.documentMode) {
-            this.walkAndSkipNestedComponents(self.$el, el => {
-                if (el.hasAttribute('x-ref')) {
-                    refObj[el.getAttribute('x-ref')] = true
-                }
-            })
-        }
+        this.walkAndSkipNestedComponents(self.$el, el => {
+            if (el.hasAttribute('x-ref')) {
+                refObj[el.getAttribute('x-ref')] = true
+            }
+        })
+        /* IE11-ONLY:END */
+
 
         // One of the goals of this is to not hold elements in memory, but rather re-evaluate
         // the DOM when the system needs something from it. This way, the framework is flexible and


### PR DESCRIPTION
I've added a rollout plugin that will remove the IE11 code from the standard version when we compile.
I think it will help this PR to be accepted.

In the future, if you put your code between `/* IE11-ONLY:START */` and `/* IE11-ONLY:END */` it will be remove when you run rollup.

I saw you changed the CustomEvent check, I personally prefer the previous version but up to you 
Both or them won't affect the standard build but I think that real custom events will have the detail property even in IE so if we skip it every time, we might miss out some feature.